### PR TITLE
fix(ci): ignore two transient Grype findings blocking the medium gate

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -26,6 +26,17 @@ ignore:
   - vulnerability: CVE-2026-7774
     package:
       name: python
+  # CVE-2026-12003 fix is only in the 3.15.0b3 prerelease; no stable 3.14 build.
+  - vulnerability: CVE-2026-12003
+    package:
+      name: python
+
+  # `time` rust crate 0.3.45 (fixed 0.3.47) is compiled into a conda binary
+  # (transitive) and is not independently bumpable from this repo; clears when
+  # the upstream conda package is rebuilt against time >= 0.3.47.
+  - vulnerability: GHSA-r6v5-fh4h-64xc
+    package:
+      name: time
 
   # pyo3 0.28.x is statically linked into the rpds-py wheel (transitive); grype
   # catalogs it from the compiled binary, but it is not fixable from this repo —


### PR DESCRIPTION
## Why

`main` went red on the **Scan dependencies with Grype** job after the routine merge of #85 (a pre-commit autoupdate that changed no dependencies). The gate (`--fail-on medium --only-fixed`) downloads a fresh vulnerability DB on every run, and the DB now flags two findings in the **unchanged** env whose only "fix" is not installable from conda-forge stable:

| Finding | Severity | "Fixed in" | Why it can't be fixed here |
|---|---|---|---|
| `CVE-2026-12003` (cpython 3.14.6) | Medium | 3.15.0**b3** | prerelease (beta); conda-forge stable has no fixed 3.14 build yet |
| `GHSA-r6v5-fh4h-64xc` (`time` 0.3.45) | Medium | 0.3.47 | rust crate compiled into a conda binary; not independently bumpable |

These are the same *fixed-only-in-a-prerelease/transitive-binary* class already accepted in this file (python CVEs, pyo3 GHSAs). No relock is needed — the pyo3 findings the DB also surfaces are already ignored here.

## Change

Two entries added to `.grype.yaml`, in the existing per-CVE style with reasons + revisit conditions.

## Verification (local)

```
grype --fail-on medium --only-fixed dir:.pixi/envs/default
→ No vulnerabilities found
pixi run test → 5 passed
```

Verified against the **current `main` env** (no lockfile change), so this PR's own CI Grype job should pass.

Assisted-With: Claude Opus 4.8 (1M context)